### PR TITLE
fetch platform components from transition phase oneops phase instead of design

### DIFF
--- a/src/main/java/com/oneops/inv/Inventory.java
+++ b/src/main/java/com/oneops/inv/Inventory.java
@@ -197,7 +197,7 @@ public class Inventory
 
         for (CiResource platform : platforms) {
             // Gather a list of components in the platform.
-            List<CiResource> components = design.listPlatformComponents(platform.getCiName());
+            List<CiResource> components = transition.listPlatformComponents(env,platform.getCiName());
 
             envByPlatformMap.put(platform, environment);
 


### PR DESCRIPTION
Currently it appears that the code is getting components from transition and iterating over the components in design to generate a list. This fails with a 404 error when assemblies have more components in transition than in design (agreed, humans are removing components in design but not pulling it)

I propose that we iterate over the transition itself so that we will not get 404s for genuine cases where we need the inventory. 

What do you think? 